### PR TITLE
Fix long annotation tooltip positioning in editor

### DIFF
--- a/dist/annotations-editing.less
+++ b/dist/annotations-editing.less
@@ -74,6 +74,7 @@
     font-style: italic;
     z-index: 2;
     transform: translateY(-100%);
+    max-width: 80vw;
     cursor: auto;
     i {
       font-size: 16px;
@@ -85,17 +86,20 @@
   .remove-annotation-area {
     cursor: pointer;
     font-style: normal;
+    position: absolute;
+    top: 13px;
+    right: 6px;
   }
   .annotation-message {
-    white-space: nowrap;
-    overflow: hidden;
-    max-width: 360px;
-    text-overflow: ellipsis;
+    display: inline-block;
+    white-space: normal;
+    width: max-content;
+    max-width: 100%;
+    padding-right: 14px; /* Leaves space for remove button */
     .unselectable;
   }
   .annotation-remove {
     padding: 8px 0 8px 6px;
-    vertical-align: middle;
     display: inline-block;
     white-space: nowrap;
     overflow: hidden;

--- a/dist/annotations-editing.less
+++ b/dist/annotations-editing.less
@@ -74,7 +74,7 @@
     font-style: italic;
     z-index: 2;
     transform: translateY(-100%);
-    max-width: 80vw;
+    max-width: calc(100vw - 16px);
     cursor: auto;
     i {
       font-size: 16px;
@@ -87,15 +87,18 @@
     cursor: pointer;
     font-style: normal;
     position: absolute;
-    top: 13px;
+    top: 10px;
     right: 6px;
   }
   .annotation-message {
     display: inline-block;
-    white-space: normal;
+    white-space: nowrap;
     width: max-content;
     max-width: 100%;
     padding-right: 14px; /* Leaves space for remove button */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1;
     .unselectable;
   }
   .annotation-remove {

--- a/src/annotations-editing.js
+++ b/src/annotations-editing.js
@@ -321,8 +321,8 @@ export function setupAnnotationDisplaying($answers, isCensor) {
     // Calculate limits for preventing overflow on either side
     const left = inlineLeftOffset(event.currentTarget)
     const pageMargin = 8
-    const leftLimit = -left + pageMargin;
-    const rightLimit = ($(window).width() - left) - $popup.outerWidth() - pageMargin;
+    const leftLimit = -left + pageMargin
+    const rightLimit = $(window).width() - left - $popup.outerWidth() - pageMargin
 
     const css = {
       left: Math.min(Math.max(mouseOffsetLeft(event) - $popup.outerWidth() / 2, leftLimit), rightLimit)
@@ -365,9 +365,11 @@ export function setupAnnotationDisplaying($answers, isCensor) {
   }
 
   function inlineLeftOffset(element) {
-    return $(element)
-      .offsetParent()
-      .offset().left + element.offsetLeft
+    return (
+      $(element)
+        .offsetParent()
+        .offset().left + element.offsetLeft
+    )
   }
 
   function mouseOffsetLeft(mousemove) {

--- a/src/annotations-editing.js
+++ b/src/annotations-editing.js
@@ -319,7 +319,7 @@ export function setupAnnotationDisplaying($answers, isCensor) {
     $annotation.append($popup)
 
     // Calculate limits for preventing overflow on either side
-    const { left } = event.currentTarget.getBoundingClientRect()
+    const left = inlineLeftOffset(event.currentTarget)
     const pageMargin = 8
     const leftLimit = -left + pageMargin;
     const rightLimit = ($(window).width() - left) - $popup.outerWidth() - pageMargin;
@@ -364,12 +364,16 @@ export function setupAnnotationDisplaying($answers, isCensor) {
     }
   }
 
+  function inlineLeftOffset(element) {
+    return $(element)
+      .offsetParent()
+      .offset().left + element.offsetLeft
+  }
+
   function mouseOffsetLeft(mousemove) {
     const annotation = mousemove.target
-    const annotationLeftOffsetFromPageEdge =
-      $(annotation)
-        .offsetParent()
-        .offset().left + annotation.offsetLeft
+    const annotationLeftOffsetFromPageEdge = inlineLeftOffset(annotation)
+
     return mousemove.pageX - annotationLeftOffsetFromPageEdge
   }
 }

--- a/src/annotations-editing.js
+++ b/src/annotations-editing.js
@@ -317,7 +317,12 @@ export function setupAnnotationDisplaying($answers, isCensor) {
     const $annotation = $(event.currentTarget)
     const $popup = popupWithMessage($annotation, $annotation.attr('data-message'))
     $annotation.append($popup)
-    const left = mouseOffsetX(event) - $popup.outerWidth() / 2
+
+    // Limit remove popup's left position based on the annotation document offset
+    const pageMargin = 8
+    const leftLimit = $annotation.offset().left
+    const left = Math.max(mouseOffsetX(event) - $popup.outerWidth() / 2, -leftLimit + pageMargin)
+
     $popup.css({ left })
     $popup.fadeIn()
   }

--- a/src/annotations-editing.js
+++ b/src/annotations-editing.js
@@ -318,12 +318,17 @@ export function setupAnnotationDisplaying($answers, isCensor) {
     const $popup = popupWithMessage($annotation, $annotation.attr('data-message'))
     $annotation.append($popup)
 
-    // Limit remove popup's left position based on the annotation document offset
+    // Calculate limits for preventing overflow on either side
+    const { left } = event.currentTarget.getBoundingClientRect()
     const pageMargin = 8
-    const leftLimit = $annotation.offset().left
-    const left = Math.max(mouseOffsetX(event) - $popup.outerWidth() / 2, -leftLimit + pageMargin)
+    const leftLimit = -left + pageMargin;
+    const rightLimit = ($(window).width() - left) - $popup.outerWidth() - pageMargin;
 
-    $popup.css({ left })
+    const css = {
+      left: Math.min(Math.max(mouseOffsetLeft(event) - $popup.outerWidth() / 2, leftLimit), rightLimit)
+    }
+
+    $popup.css(css)
     $popup.fadeIn()
   }
 
@@ -359,7 +364,7 @@ export function setupAnnotationDisplaying($answers, isCensor) {
     }
   }
 
-  function mouseOffsetX(mousemove) {
+  function mouseOffsetLeft(mousemove) {
     const annotation = mousemove.target
     const annotationLeftOffsetFromPageEdge =
       $(annotation)


### PR DESCRIPTION
Changes to annotation remove tooltip
- Text wraps
- Positioning is clamped inside the window

Things that aren't fixed in this PR:
- Tooltip can still be obscured under position: 'fixed' elements (which has to be fixed in sa-yo)